### PR TITLE
Correção de inserção com valor nulo, criação de cenário de teste

### DIFF
--- a/dist/database.js
+++ b/dist/database.js
@@ -405,7 +405,7 @@ function tableInsert(ds, table, itens) {
     for (var key in reg) {
       value = reg[key]
       cols += vrg + '"' + key + '"'
-      values += (value.constructor.name === 'Number')
+      values += (value === null || value.constructor.name === 'Number')
         ? (vrg + value)
         : (vrg + sdel + value + sdel)
 

--- a/test/test.database.js
+++ b/test/test.database.js
@@ -245,8 +245,14 @@ function exec(describe, it, beforeEach, afterEach, expect, should, assert) {
         expect(db.execute('SELECT * FROM "ttest"').length).to.equal(3)
       })
 
+      it('Inserindo registro com valor nulo na table com api [insert]', function() {
+        let regs = [{ num: 16, txt: null }]
+        expect(db.insert('ttest', regs).error).to.equal(false)
+      })
+
       it('Apagando registro(s) da tabela DELETE table (com where)', function() {
         expect(db.delete('ttest', { num: 11 }).error).to.equal(false)
+        expect(db.delete('ttest', { num: 16 }).error).to.equal(false)
         expect(db.execute('SELECT * FROM "ttest"').length).to.equal(2)
       })
     })


### PR DESCRIPTION
Resolvendo problema de inserção de registro com um dos parâmetros igual a nulo. A API estava passando nulo como string o que estava explodindo erro no banco.

Criação de cenário de teste para este caso.